### PR TITLE
Japanese support

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -7,6 +7,9 @@ module = "zref-vario"
 -- Typeset only the .tex files
 typesetfiles = {"*.tex"}
 
+-- Use lualatex for compiling docs
+typesetexe = "lualatex"
+
 -- Three runs
 checkruns = 3
 

--- a/zref-vario-code.tex
+++ b/zref-vario-code.tex
@@ -41,6 +41,18 @@
 
 \documentclass{l3doc}
 
+\usepackage[main=english]{babel}
+\usepackage{fontspec}
+
+\babelfont{rm}{CMU Serif}
+\babelfont{sf}{CMU Sans Serif}
+\babelfont{tt}{CMU Typewriter Text}
+
+\babelprovide[onchar=ids fonts]{japanese}
+\babelfont[japanese]{rm}{Harano Aji Mincho}
+\babelfont[japanese]{sf}[Scale=0.9]{Harano Aji Gothic}
+\babelfont[japanese]{tt}[Scale=0.8]{Harano Aji Gothic}
+
 % Have \GetFileInfo pick up date and version data.
 \usepackage{zref-vario}
 

--- a/zref-vario.dtx
+++ b/zref-vario.dtx
@@ -1277,6 +1277,24 @@
 %
 %
 %    \begin{macrocode}
+\zvLanguageSetup { japanese }
+  {
+    reftextfaceafter  = {\zvhyperlink{\reftextvario{見開き}{次}ページ}} ,
+    reftextfacebefore = {\zvhyperlink{\reftextvario{見開き}{前}ページ}} ,
+    reftextafter      = {\zvhyperlink{\reftextvario{直後の}{次}ページ}} ,
+    reftextbefore     = {\zvhyperlink{\reftextvario{直前の}{前}ページ}} ,
+    reftextcurrent    = {\zvhyperlink{\reftextvario{この}{現}ページ}} ,
+    reftextfaraway    = {\zcpageref{#1}} ,
+    reftextpagerange  = {\zcpageref[range]{#1,#2}} ,
+    reftextlabelrange = {\zcref[range]{#1,#2}} ,
+    vrefformat        = {\zcref{#2}（\zvpageref[#1]{#2}）} ,
+    vrefrangeformat   = {\zcref[range]{#2,#3}（\vpagerefrange[{#1}]{#2}{#3}）} ,
+    fullrefformat     = {\zcref{#1}（\reftextfaraway{#1}）} ,
+  }
+%    \end{macrocode}
+%
+%
+%    \begin{macrocode}
 %</package>
 %    \end{macrocode}
 %


### PR DESCRIPTION
[Japanese translation of varioref][varioref] has been directly transcribed into zref-vario.

[varioref]: https://github.com/latex3/latex2e/blob/8b5d2086698cbaf2d58362fe2a35170cb7733d95/required/tools/varioref.dtx#L1348-L1367 "latex2e/required/tools/varioref.dtx at 8b5d2086698cbaf2d58362fe2a35170cb7733d95 · latex3/latex2e"
